### PR TITLE
Added style and FR translations to sign_in and sign_up forms

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby "3.1.2"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.3", ">= 7.0.3.1"
+gem "rails-i18n"
 
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
@@ -29,6 +30,8 @@ gem "jbuilder"
 
 # devise
 gem "devise"
+
+gem "devise-i18n"
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.10.2)
+      devise (>= 4.8.0)
     digest (3.1.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
@@ -184,6 +186,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.3.1)
       actionpack (= 7.0.3.1)
       activesupport (= 7.0.3.1)
@@ -261,6 +266,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  devise-i18n
   dotenv-rails
   font-awesome-sass (~> 6.1)
   jbuilder
@@ -268,6 +274,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)
+  rails-i18n
   sassc-rails
   selenium-webdriver
   simple_form!

--- a/app/assets/stylesheets/components/_container-form.scss
+++ b/app/assets/stylesheets/components/_container-form.scss
@@ -1,0 +1,5 @@
+.container-form{
+  width: 500px;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/app/assets/stylesheets/components/_form-links.scss
+++ b/app/assets/stylesheets/components/_form-links.scss
@@ -1,0 +1,8 @@
+.form-link{
+text-decoration: none;
+}
+
+.form-link:hover{
+  text-decoration: none;
+  opacity: 0.5;
+  }

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -3,3 +3,4 @@
 @import "avatar";
 @import "form_legend_clear";
 @import "navbar";
+@import "container-form";

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -4,3 +4,4 @@
 @import "form_legend_clear";
 @import "navbar";
 @import "container-form";
+@import "form-links"

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,33 +1,35 @@
-<h2>Sign up</h2>
+<div class="container-form bg-light text-dark p-4 mt-4 rounded-4">
+  <h2 class="text-center">Inscription</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: {turbo: false}) do |f| %>
-  <%= f.error_notification %>
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: {turbo: false}) do |f| %>
+    <%= f.error_notification %>
 
-  <div class="form-inputs">
-    <%= f.input :first_name,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "first-name" }%>
-    <%= f.input :last_name,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "last-name" }%>
-    <%= f.input :email,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "email" }%>
-    <%= f.input :password,
-                required: true,
-                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: true,
-                input_html: { autocomplete: "new-password" } %>
-  </div>
+    <div class="form-inputs">
+      <%= f.input :first_name, label: "Prénom",
+                  required: true,
+                  autofocus: true,
+                  input_html: { autocomplete: "first-name" }%>
+      <%= f.input :last_name, label: "Nom",
+                  required: true,
+                  autofocus: true,
+                  input_html: { autocomplete: "last-name" }%>
+      <%= f.input :email, label: "Adresse e-mail",
+                  required: true,
+                  autofocus: true,
+                  input_html: { autocomplete: "email" }%>
+      <%= f.input :password, label: "Mot de passe",
+                  required: true,
+                  hint: ("#{@minimum_password_length} caractères minimum" if @minimum_password_length),
+                  input_html: { autocomplete: "new-password" } %>
+      <%= f.input :password_confirmation, label: "Saisir à nouveau le mot de passe",
+                  required: true,
+                  input_html: { autocomplete: "new-password" } %>
+    </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
-  </div>
-<% end %>
+    <div class="form-actions text-center">
+      <%= f.button :submit, "Inscription", class: "btn btn-primary mb-2" %>
+    </div>
+  <% end %>
 
-<%= render "devise/shared/links" %>
+  <%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,23 +5,23 @@
     <%= f.error_notification %>
 
     <div class="form-inputs">
-      <%= f.input :first_name, label: "Prénom",
+      <%= f.input :first_name,
                   required: true,
                   autofocus: true,
                   input_html: { autocomplete: "first-name" }%>
-      <%= f.input :last_name, label: "Nom",
+      <%= f.input :last_name,
                   required: true,
                   autofocus: true,
                   input_html: { autocomplete: "last-name" }%>
-      <%= f.input :email, label: "Adresse e-mail",
+      <%= f.input :email,
                   required: true,
                   autofocus: true,
                   input_html: { autocomplete: "email" }%>
-      <%= f.input :password, label: "Mot de passe",
+      <%= f.input :password,
                   required: true,
                   hint: ("#{@minimum_password_length} caractères minimum" if @minimum_password_length),
                   input_html: { autocomplete: "new-password" } %>
-      <%= f.input :password_confirmation, label: "Saisir à nouveau le mot de passe",
+      <%= f.input :password_confirmation,
                   required: true,
                   input_html: { autocomplete: "new-password" } %>
     </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container-form bg-light text-dark p-4 mt-4 rounded-4">
+<div class="container-form bg-light text-dark p-4 mt-4 rounded-4 shadow">
   <h2 class="text-center">Inscription</h2>
 
   <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), data: {turbo: false}) do |f| %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -4,11 +4,11 @@
 
   <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), data: {turbo: false}) do |f| %>
     <div class="form-inputs">
-      <%= f.input :email, label: "Adresse e-mail",
+      <%= f.input :email,
                   required: false,
                   autofocus: true,
                   input_html: { autocomplete: "email" } %>
-      <%= f.input :password, label: "Mot de passe",
+      <%= f.input :password,
                   required: false,
                   input_html: { autocomplete: "current-password" } %>
       <%= f.input :remember_me, label: "Mémoriser", as: :boolean if devise_mapping.rememberable? %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,28 +1,23 @@
-<h2>Log in</h2>
+<div class="container-form bg-light text-dark p-4 mt-4 rounded-4">
+  <h2 class="text-center">Connexion</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), data: {turbo: false}) do |f| %>
-  <div class="form-inputs">
-    <%= f.input :first_name,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "first-name" }%>
-    <%= f.input :last_name,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "last-name" }%>
-    <%= f.input :email,
-                required: false,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
-    <%= f.input :password,
-                required: false,
-                input_html: { autocomplete: "current-password" } %>
-    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
-  </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
-  </div>
-<% end %>
+  <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name), data: {turbo: false}) do |f| %>
+    <div class="form-inputs">
+      <%= f.input :email, label: "Adresse e-mail",
+                  required: false,
+                  autofocus: true,
+                  input_html: { autocomplete: "email" } %>
+      <%= f.input :password, label: "Mot de passe",
+                  required: false,
+                  input_html: { autocomplete: "current-password" } %>
+      <%= f.input :remember_me, label: "Mémoriser", as: :boolean if devise_mapping.rememberable? %>
+    </div>
 
-<%= render "devise/shared/links" %>
+    <div class="form-actions text-center">
+      <%= f.button :submit, "Connexion", class: "btn btn-primary mb-2"%>
+    </div>
+  <% end %>
+
+  <%= render "devise/shared/links"%>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container-form bg-light text-dark p-4 mt-4 rounded-4">
+<div class="container-form bg-light text-dark p-4 mt-4 rounded-4 shadow">
   <h2 class="text-center">Connexion</h2>
 
 

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Connexion", new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "Inscription", new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to "Mot de passe oublié ?", new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Vous n'avez pas reçu les informations de confirmation ?", new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to "Vous n'avez pas reçu les instructions de déverrouillage ?", new_unlock_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <%= link_to "Se connecter avec #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
   <% end %>
 <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Connexion", new_session_path(resource_name) %><br />
+  <%= link_to "Connexion", new_session_path(resource_name), class: "form-link" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Inscription", new_registration_path(resource_name) %><br />
+  <%= link_to "Inscription", new_registration_path(resource_name), class: "form-link" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Mot de passe oublié ?", new_password_path(resource_name) %><br />
+  <%= link_to "Mot de passe oublié ?", new_password_path(resource_name), class: "form-link" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Vous n'avez pas reçu les informations de confirmation ?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Vous n'avez pas reçu les informations de confirmation ?", new_confirmation_path(resource_name), class: "form-link" %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Vous n'avez pas reçu les instructions de déverrouillage ?", new_unlock_path(resource_name) %><br />
+  <%= link_to "Vous n'avez pas reçu les instructions de déverrouillage ?", new_unlock_path(resource_name), class: "form-link" %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Se connecter avec #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <%= link_to "Se connecter avec #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post, class: "form-link" %><br />
   <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,6 @@ module Deguizbe
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.default_locale = :fr
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,40 @@
+# Files in the config/locales directory are used for internationalization
+# and are automatically loaded by Rails. If you want to use locales other
+# than English, add the necessary files in this directory.
+#
+# To use the locales, use `I18n.t`:
+#
+#     I18n.t "hello"
+#
+# In views, this is aliased to just `t`:
+#
+#     <%= t("hello") %>
+#
+# To use a different locale, set it with `I18n.locale`:
+#
+#     I18n.locale = :es
+#
+# This would use the information in config/locales/es.yml.
+#
+# The following keys must be escaped otherwise they will not be retrieved by
+# the default I18n backend:
+#
+# true, false, on, off, yes, no
+#
+# Instead, surround them with single quotes.
+#
+# en:
+#   "true": "foo"
+#
+# To learn more, please read the Rails Internationalization guide
+# available at https://guides.rubyonrails.org/i18n.html.
+
+fr:
+  activerecord:
+    attributes:
+      user:
+        first_name: "Prénom"
+        last_name: "Nom"
+        email: "Adresse e-mail"
+        password: "Mot de passe"
+        password_confirmation: "Saisir à nouveau le mot de passe"

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -1,0 +1,31 @@
+fr:
+  simple_form:
+    "yes": 'Oui'
+    "no": 'Non'
+    required:
+      text: 'requis'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Veuillez corriger votre saisie."
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'


### PR DESCRIPTION
## Style (on sign_in and sign_up views)
- Form box centered, light background, border-radius, shadow
- Centered title
- Applied Bootstrap class btn-primary to main button + centered button
- Reworked CSS on form links (no decoration + lighter opacity on hover)

## Localization
- Added i18n gems to cater for French error messages
- Translated form input labels and links